### PR TITLE
Add Vagrant plugin for installing virtualbox guest additions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,12 @@ SCRIPT
 
 Vagrant.configure("2") do |config|
 
+  # The CentOS 7 box does not include Virtualbox guest additions needed
+  # to share folders between the host and guest VMs.
+  # This install a plugin to automatically install/update guest additions
+  # https://github.com/dotless-de/vagrant-vbguest
+  config.vagrant.plugins = "vagrant-vbguest"
+
   config.vm.box = "centos/7"
   config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   config.vm.provision "shell",


### PR DESCRIPTION
Add Vagrant plugin for installing virtualbox guest additions on the CentOS 7 box. This is needed for setting up the shared folder.

Without this plugin you get the following error when using VirtualBox. There might be a way to make this conditional 

`Vagrant was unable to mount VirtualBox shared folders. This is usually
because the filesystem "vboxsf" is not available. This filesystem is
made available via the VirtualBox Guest Additions and kernel module.
Please verify that these guest additions are properly installed in the
guest. This is not a bug in Vagrant and is usually caused by a faulty
Vagrant box. For context, the command attempted was:

mount -t vboxsf -o uid=1000,gid=1000 vagrant /vagrant

The error output from the command was:

mount: unknown filesystem type 'vboxsf'
`